### PR TITLE
Show hidden Ordered List numbers in forum.css

### DIFF
--- a/public/css/forum.css
+++ b/public/css/forum.css
@@ -37,8 +37,16 @@ b, strong {
     font-weight:bolder;
 }
 
-ol, ul {
-    list-style: none;
+ul {
+    list-style: none
+}
+
+ol{
+	padding-left:30px;
+}
+
+ol li{
+	margin: 5px 0
 }
 
 p {

--- a/public/css/forum.css
+++ b/public/css/forum.css
@@ -42,11 +42,11 @@ ul {
 }
 
 ol{
-	padding-left:30px;
+    padding-left:30px;
 }
 
 ol li{
-	margin: 5px 0
+    margin: 5px 0
 }
 
 p {


### PR DESCRIPTION
uncoupled ol & li rules so that the numbers show up on ordered lists.  Gave the OL 20 px padding and the LI a margin of 5px to match (vby eye) the existing unordered list style.