### PR TITLE
better Vimeo embeds

### DIFF
--- a/public/css/forum.css
+++ b/public/css/forum.css
@@ -2157,12 +2157,10 @@ Award Section
 /* -- Responsive Embed: http://embedresponsively.com/ ---------------------- */
 .embed-container { 
     position: relative; 
-    padding-bottom: 56.25%; 
-    padding-top: 30px; 
-    height: 0; 
-    overflow: hidden; 
-    max-width: 640px; /*100%;*/ 
-    height: auto; 
+    padding-bottom: 56.25%;
+    height: 0;
+    overflow: hidden;
+    max-width: 100%;
 } 
 
 .embed-container iframe, 


### PR DESCRIPTION
Vimeo embeds this makes a weird shaped box with giant letterboxes on the top and bottom. I removed the weird height:auto and max-width:640px from the embed-container class.

This follows the suggested Vimeo responsive embed from http://embedresponsively.com/.  Vimeo embeds now fill the entire width of the content area, instead of the weird giant box thing. Youtube embeds behave the same.

Resizing the window, things behave as expected...

The inconsistency between the size of a Vimeo embed and the size of a Youtube embed, I would argue, is desirable as Vimeo has a greater cultural focus on aesthetics and their videos are more likely to be grand vistas in the church of cinema as opposed to youtube's full length VHS bootleg of James Spader's 'Tuff Turf' from 1985 in 320p.

As a side note this does not effect the size of Vimeo embeds where the entire iframe code is pasted, only when the URL is used.

Tested in safari, chrome & firefox on a mac...